### PR TITLE
ADIT-157, fixing issue where query string would sometimes be cut short

### DIFF
--- a/client/src/main/java/org/apache/predictionio/sdk/java/EngineClient.java
+++ b/client/src/main/java/org/apache/predictionio/sdk/java/EngineClient.java
@@ -18,6 +18,7 @@
 package org.apache.predictionio.sdk.java;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -108,6 +109,7 @@ public class EngineClient extends BaseClient {
     String requestJsonString = gson.toJson(query);
     builder.setBody(requestJsonString);
     builder.setHeader("Content-Type", "application/json");
+    builder.setHeader("Content-Length", "" + requestJsonString.getBytes(StandardCharsets.UTF_8).length);
     return new FutureAPIResponse(client.executeRequest(builder.build(), getHandler()));
   }
 

--- a/client/src/main/java/org/apache/predictionio/sdk/java/EngineClient.java
+++ b/client/src/main/java/org/apache/predictionio/sdk/java/EngineClient.java
@@ -17,13 +17,15 @@
 
 package org.apache.predictionio.sdk.java;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import org.asynchttpclient.RequestBuilder;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+import org.asynchttpclient.RequestBuilder;
 import org.joda.time.DateTime;
 
 /**
@@ -106,7 +108,6 @@ public class EngineClient extends BaseClient {
     String requestJsonString = gson.toJson(query);
     builder.setBody(requestJsonString);
     builder.setHeader("Content-Type", "application/json");
-    builder.setHeader("Content-Length", "" + requestJsonString.length());
     return new FutureAPIResponse(client.executeRequest(builder.build(), getHandler()));
   }
 

--- a/client/src/main/java/org/apache/predictionio/sdk/java/EngineClient.java
+++ b/client/src/main/java/org/apache/predictionio/sdk/java/EngineClient.java
@@ -108,7 +108,7 @@ public class EngineClient extends BaseClient {
 
     String requestJsonString = gson.toJson(query);
     builder.setBody(requestJsonString);
-    builder.setHeader("Content-Type", "application/json");
+    builder.setHeader("Content-Type", "application/json; charset=UTF-8");
     builder.setHeader("Content-Length", "" + requestJsonString.getBytes(StandardCharsets.UTF_8).length);
     return new FutureAPIResponse(client.executeRequest(builder.build(), getHandler()));
   }

--- a/client/src/main/java/org/apache/predictionio/sdk/java/FutureAPIResponse.java
+++ b/client/src/main/java/org/apache/predictionio/sdk/java/FutureAPIResponse.java
@@ -17,12 +17,14 @@
 
 package org.apache.predictionio.sdk.java;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import org.asynchttpclient.extras.guava.ListenableFutureAdapter;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.asynchttpclient.extras.guava.ListenableFutureAdapter;
 
 /**
  * APIResponse as a listenable future.
@@ -37,7 +39,6 @@ public class FutureAPIResponse implements ListenableFuture<APIResponse> {
 
   public FutureAPIResponse(org.asynchttpclient.ListenableFuture<APIResponse> apiResponse) {
     this.apiResponse = ListenableFutureAdapter.asGuavaFuture(apiResponse);
-    //this.apiResponse = apiResponse;
   }
 
   // implements ListenableFuture<APIResponse>


### PR DESCRIPTION
The query string sent through sendQueryAsFuture to the AsyncHttpClient would be cut short when certain files were ingested, causing a MalformedJsonException - but removing the Content-Length header seems to fix this issue